### PR TITLE
Add `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+__pycache__


### PR DESCRIPTION
Making git ignore the files generated by the Python package build process.