### PR TITLE
Add support for standalone installation in Python using the modularized passagemath distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+__pycache__

--- a/CompGIT/Git.py
+++ b/CompGIT/Git.py
@@ -23,7 +23,10 @@ from sage.geometry.polyhedron.constructor import Polyhedron
 from sage.modules.free_module import VectorSpace
 from sage.rings.rational_field import QQ
 from sage.sets.set import Set
-from sage.all import QuadraticField, matrix, vector, sqrt
+from sage.rings.number_field.number_field import QuadraticField
+from sage.matrix.constructor import Matrix as matrix
+from sage.modules.free_module_element import free_module_element as vector
+from sage.misc.functional import sqrt
 
 from SimpleGroup import SimpleGroup, one_param_subgroup
 

--- a/CompGIT/Git.py
+++ b/CompGIT/Git.py
@@ -28,7 +28,7 @@ from sage.matrix.constructor import Matrix as matrix
 from sage.modules.free_module_element import free_module_element as vector
 from sage.misc.functional import sqrt
 
-from SimpleGroup import SimpleGroup, one_param_subgroup
+from .SimpleGroup import SimpleGroup, one_param_subgroup
 
 
 K2 = QuadraticField(2, 'sqrt2')

--- a/CompGIT/Git.py
+++ b/CompGIT/Git.py
@@ -53,7 +53,7 @@ def proportional(v1, v2) -> bool:
 
     EXAMPLES::
 
-        sage: from Git import proportional
+        sage: from CompGIT.Git import proportional
         sage: v1 = vector([2,0,6])
         sage: v2 = vector([6,9,1])
         sage: proportional(v1, 2*v1)
@@ -77,7 +77,7 @@ def weights_matrix(weights_set, field=QQ):
 
     EXAMPLES::
 
-        sage: from Git import weights_matrix
+        sage: from CompGIT.Git import weights_matrix
         sage: weights = ([1,2], [3,4])
         sage: weights_matrix(weights)
         [1 2]
@@ -103,7 +103,7 @@ def averageWeight(x):
 
     EXAMPLES::
 
-        sage: from Git import averageWeight
+        sage: from CompGIT.Git import averageWeight
         sage: weights_set = ([1,2], [3,4])
         sage: averageWeight(weights_set)
         (2, 3)
@@ -135,7 +135,7 @@ class GITProblem(object):
     EXAMPLES::
 
         # Cubics in P2
-        sage: from Git import GITProblem
+        sage: from CompGIT.Git import GITProblem
         sage: Phi = WeylCharacterRing("A2")
         sage: representation= Phi(3,0,0)
         sage: P=GITProblem(representation,label="Plane cubics")
@@ -288,7 +288,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation,label="Plane cubics")
@@ -335,7 +335,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation,label="Plane cubics")
@@ -380,7 +380,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation,label="Plane cubics")
@@ -400,7 +400,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -438,7 +438,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -483,7 +483,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -596,7 +596,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -703,7 +703,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -767,7 +767,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -811,7 +811,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -842,7 +842,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation = Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -885,7 +885,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -919,7 +919,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -970,7 +970,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)
@@ -1008,7 +1008,7 @@ class GITProblem(object):
 
         EXAMPLES::
 
-            sage: from Git import GITProblem
+            sage: from CompGIT.Git import GITProblem
             sage: Phi = WeylCharacterRing("A2")
             sage: representation= Phi(3,0,0)
             sage: P=GITProblem(representation)

--- a/CompGIT/SimpleGroup.py
+++ b/CompGIT/SimpleGroup.py
@@ -39,7 +39,7 @@ def upper_triangular_entries(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import upper_triangular_entries
+        sage: from CompGIT.SimpleGroup import upper_triangular_entries
         sage: upper_triangular_entries(2, 0, 1)
         1
         sage: upper_triangular_entries(2, 1, 0)
@@ -61,7 +61,7 @@ def lower_triangular_entries(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import lower_triangular_entries
+        sage: from CompGIT.SimpleGroup import lower_triangular_entries
         sage: lower_triangular_entries(2, 0, 1)
         0
         sage: lower_triangular_entries(2, 1, 0)
@@ -85,7 +85,7 @@ def one_param_subgroup(data, type_A=False, field=QQ):
 
     EXAMPLES::
 
-        sage: from SimpleGroup import one_param_subgroup
+        sage: from CompGIT.SimpleGroup import one_param_subgroup
         sage: v1 = vector([2, 1, -3])
         sage: v2 = vector([3, 2, 1])
         sage: one_param_subgroup(v1, type_A=True)
@@ -112,7 +112,7 @@ def A_coord_change_from_T_to_H(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import A_coord_change_from_T_to_H
+        sage: from CompGIT.SimpleGroup import A_coord_change_from_T_to_H
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -136,7 +136,7 @@ def inverse_of_upper_triangular(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import inverse_of_upper_triangular
+        sage: from CompGIT.SimpleGroup import inverse_of_upper_triangular
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -158,7 +158,7 @@ def inverse_of_upper_triangular(rnk, x, y):
 #
 #    EXAMPLES::
 #
-#        sage: from SimpleGroup import A_cone_basis_constructor
+#        sage: from CompGIT.SimpleGroup import A_cone_basis_constructor
 #        sage: x = 2
 #        sage: y = 3
 #        sage: rnk = 5
@@ -180,7 +180,7 @@ def A_cone_basis_constructor_from_T(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import A_cone_basis_constructor_from_T
+        sage: from CompGIT.SimpleGroup import A_cone_basis_constructor_from_T
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -203,7 +203,7 @@ def A_T_basis_constructor_from_gamma(rnk, x, y):
 
     EXAMPLES::
         
-        sage: from SimpleGroup import A_T_basis_constructor_from_gamma
+        sage: from CompGIT.SimpleGroup import A_T_basis_constructor_from_gamma
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -225,7 +225,7 @@ def D_cone_basis_constructor(rnk, x, y):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import D_cone_basis_constructor
+        sage: from CompGIT.SimpleGroup import D_cone_basis_constructor
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -249,7 +249,7 @@ def D_T_basis_constructor_from_gamma(rnk, x, y):
 
     EXAMPLES::
         
-        sage: from SimpleGroup import D_T_basis_constructor_from_gamma
+        sage: from CompGIT.SimpleGroup import D_T_basis_constructor_from_gamma
         sage: x = 2
         sage: y = 3
         sage: rnk = 5
@@ -415,7 +415,7 @@ class SimpleGroup(object):
     
     EXAMPLES::
         
-        sage: from SimpleGroup import SimpleGroup
+        sage: from CompGIT.SimpleGroup import SimpleGroup
         sage: G=SimpleGroup("A", 2)
         sage: G.group_type()
         'A'
@@ -581,7 +581,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.Weyl_Group_elements()
             Weyl Group of type ['A', 2] (as a matrix group acting on the ambient space)
@@ -595,7 +595,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.fundamental_chamber_generators()
             [2 1]
@@ -609,7 +609,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.pairing(1, [1,2])
             (-1, 2)
@@ -625,7 +625,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.fetch_pairing_matrix()
             [ 1 -1]
@@ -639,7 +639,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.in_cone(1)
             False
@@ -657,7 +657,7 @@ class SimpleGroup(object):
         
             EXAMPLES::
             
-            sage: from SimpleGroup import SimpleGroup 
+            sage: from CompGIT.SimpleGroup import SimpleGroup 
             sage: G = SimpleGroup("A", 2)
             sage: G.H_coordinates(1)
             [ 1  0]

--- a/CompGIT/SimpleGroup.py
+++ b/CompGIT/SimpleGroup.py
@@ -16,10 +16,11 @@ REFERENCES:
 - [HMG] R. Hanson, J. Martinez-Garcia "CompGIT, a Sagemath package for Geometric Invariant Theory". To appear.
 """
 
-from sage.matrix.constructor import Matrix
-from sage.rings.rational_field import QQ
+from sage.combinat.root_system.weyl_group import WeylGroup
+from sage.matrix.constructor import Matrix, matrix
 from sage.modules.free_module_element import vector
 from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.rational_field import QQ
 
 K2 = QuadraticField(2, 'sqrt2')
 sqrt2 = K2.gen()

--- a/CompGIT/SimpleGroup.py
+++ b/CompGIT/SimpleGroup.py
@@ -16,12 +16,10 @@ REFERENCES:
 - [HMG] R. Hanson, J. Martinez-Garcia "CompGIT, a Sagemath package for Geometric Invariant Theory". To appear.
 """
 
-#from sage.modules.vector_rational_dense import Vector_rational_dense
-#from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix
 from sage.rings.rational_field import QQ
 from sage.modules.free_module_element import vector
-from sage.all import *
-
+from sage.rings.number_field.number_field import QuadraticField
 
 K2 = QuadraticField(2, 'sqrt2')
 sqrt2 = K2.gen()

--- a/CompGIT/__init__.py
+++ b/CompGIT/__init__.py
@@ -1,9 +1,9 @@
 from sage.all import *
 from sage.all import WeylGroup #experimental purposes only
-from CompGIT import SimpleGroup
-from CompGIT import Git
+from . import SimpleGroup
+from . import Git
 
-from SimpleGroup import (upper_triangular_entries,
+from .SimpleGroup import (upper_triangular_entries,
                          lower_triangular_entries,
                          one_param_subgroup,
                          A_coord_change_from_T_to_H,
@@ -15,7 +15,7 @@ from SimpleGroup import (upper_triangular_entries,
                          D_T_basis_constructor_from_gamma,
                          SimpleGroup)
 
-from Git import (proportional,
+from .Git import (proportional,
                  weights_matrix,
                  averageWeight,
                  GITProblem)

--- a/CompGIT/__init__.py
+++ b/CompGIT/__init__.py
@@ -1,5 +1,10 @@
-from sage.all import *
-from sage.all import WeylGroup #experimental purposes only
+try:
+    from sage.all__sagemath_combinat import *
+    from sage.all__sagemath_modules import *
+except ImportError:  # try monolithic Sage
+    from sage.all import *
+    from sage.all import WeylGroup #experimental purposes only
+
 from . import SimpleGroup
 from . import Git
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Please consider citing the following references if you use this software for you
 * P. Gallardo, J. Martinez-Garcia, H-B Moon, and D. Swinarski. “Computation of GIT quotients of semisimple groups”. arXiv:2308.08049 (2023).
 * R. Hanson and J. Martinez-Garcia. The CompGIT GitHub homepage. https://github.com/Robbie-H/CompGIT.
 
-# Dependencies 
+# Installation with pip in SageMath
+
+## Dependencies 
 
 * SageMath version 9.0 or later and the SageMath standard library, 
 * Python version 3.9 or later
@@ -30,14 +32,23 @@ Please consider citing the following references if you use this software for you
 The Sage installation guide is available [here](https://doc.sagemath.org/html/en/installation/index.html)
 
 Commands are run within a console, such as the SageMath Shell on linux or terminal on MacOS. Once a sage session is launched, we include the prompt ‘sage:’ in our code.  
- 
-# Installation with pip 
+
+## Installation
 
 To add CompGIT to your SageMath installation, first download CompGIT as a ```.zip``` file from the [CompGIT GitHub homepage](https://github.com/Robbie-H/CompGIT) and then run the console command 
 
 ```
 sage -pip install (location of CompGIT)
 ```
+
+# Standalone installation with pip (no SageMath installation required)
+
+The package can also be installed in plain Python using the modularized distributions of the Sage library from the [passagemath](https://github.com/passagemath) project.
+
+```
+pip install "(location of CompGIT)[passagemath]"
+```
+
 
 # Example 
 

--- a/README.md
+++ b/README.md
@@ -98,23 +98,7 @@ An example for cubic surfaces is worked out in the paper. In it, one can read ho
 
 # Running doctests
 
-To run doctests for CompGIT, extract the files from the ```.zip``` into some folder. Make sure that you have a system variable called ```PYTHONPATH``` and include in it the path to the subfolder with ```CompGIT``` in it (the one with the file ```GIT.py``` in it). To check if the system variable exist you can run 
-
-```printenv PYTHONPATH```
-
-If something appears but not the CompGIT directory, write
-
-```export PYTHONPATH="${PYTHONPATH}:directory"```
-
-where ```directory``` is replaced by the full CompGIT source path.
-
-If when calling ```printenv``` above no paths are produced, then write
-
-```export PYTHONPATH="directory"```
-
-where ```directory``` is replaced by the full CompGIT source path.
-
-If when calling ```printenv``` you do see the CompGIT source path, you do not have to do anything, continue to the next step.
+To run doctests for CompGIT, extract the files from the ```.zip``` into some folder.
 
 Then, from the ```CompGIT``` subfolder (where ```GIT.py``` is stored) run
 

--- a/_doctest_environment.py
+++ b/_doctest_environment.py
@@ -1,0 +1,4 @@
+# Toplevel for doctesting with passagemath
+
+from sage.all__sagemath_combinat import *  # noqa: F403
+from sage.all__sagemath_modules import *  # noqa: F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 passagemath = [
   "passagemath-combinat",
+  "passagemath-flint",
   "passagemath-graphs",
   "passagemath-groups",
   "passagemath-modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,15 @@ classifiers = [
     ]
 requires-python = ">=3.9"
 
+[project.optional-dependencies]
+passagemath = [
+  "passagemath-combinat",
+  "passagemath-graphs",
+  "passagemath-groups",
+  "passagemath-modules",
+  "passagemath-polyhedra",
+  "passagemath-repl",
+]
 
 [tool.setuptools]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ passagemath = [
   "passagemath-graphs",
   "passagemath-groups",
   "passagemath-modules",
+  "passagemath-pari",
   "passagemath-polyhedra",
   "passagemath-repl",
+  "scipy",
 ]
 
 [tool.setuptools]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = passagemath
+
+[testenv:.pkg]
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+[testenv:passagemath]
+usedevelop = True
+extras = passagemath
+
+setenv =
+    # For access to _doctest_environment.py
+    PYTHONPATH=.
+
+commands =
+    sage -tp --force-lib --environment=_doctest_environment CompGIT


### PR DESCRIPTION
See changes in README for installation instructions.

To test, type `tox`.

The branch is on top of 
- #22 
- #23 
- #24 
